### PR TITLE
modernize

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ find_package (Qt5 COMPONENTS Core Network Qml Gui Quick REQUIRED)
 
 include(FindPkgConfig)
 pkg_search_module(SAILFISH sailfishapp REQUIRED)
-add_definitions(-DSAILFISHAPP)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,33 +1,38 @@
 project(cmakesample CXX)
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.5)
 
-find_package(Qt5Qml REQUIRED)
+find_package (Qt5 COMPONENTS Core Network Qml Gui Quick REQUIRED)
 
 include(FindPkgConfig)
 pkg_search_module(SAILFISH sailfishapp REQUIRED)
+add_definitions(-DSAILFISHAPP)
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(cmakesample main.cpp)
-set_property(TARGET cmakesample
-  PROPERTY INCLUDE_DIRECTORIES
-  INCLUDE_DIRECTORIES "${SAILFISH_INCLUDE_DIRS}")
-qt5_use_modules(cmakesample Qml)
-target_link_libraries(cmakesample ${SAILFISH_LDFLAGS})
+target_include_directories(cmakesample PRIVATE
+    $<BUILD_INTERFACE:
+    ${SAILFISH_INCLUDE_DIRS}
+>)
+target_link_libraries(cmakesample
+    Qt5::Quick
+    ${SAILFISH_LDFLAGS}
+)
 
 install(TARGETS cmakesample
-RUNTIME DESTINATION bin)
-
+    RUNTIME DESTINATION bin
+)
 install(DIRECTORY qml
-DESTINATION share/cmakesample)
-
+    DESTINATION share/cmakesample
+)
 install(DIRECTORY translations
-DESTINATION share/cmakesample
-FILES_MATCHING PATTERN "*.qm")
-
+    DESTINATION share/cmakesample
+    FILES_MATCHING PATTERN "*.qm"
+)
 install(FILES cmakesample.desktop
-DESTINATION share/applications)
-
+    DESTINATION share/applications
+)
 install(FILES cmakesample.png
-DESTINATION share/icons/hicolor/86x86/apps)
+    DESTINATION share/icons/hicolor/86x86/apps
+)

--- a/main.cpp
+++ b/main.cpp
@@ -32,15 +32,12 @@
 #include <QtQuick>
 #endif
 
-#include<QCoreApplication>
-
 //FIXME, get path properly.
 #include <sailfishapp.h>
 
-
 int main(int argc, char *argv[])
 {
-    // SailfishApp::main() will display "qml/template.qml", if you need more
+    // SailfishApp::main() will display "qml/cmakesample.qml", if you need more
     // control over initialization, you can use:
     //
     //   - SailfishApp::application(int, char *[]) to get the QGuiApplication *


### PR DESCRIPTION
Raise the minimum required CMake version to 3.5 (requires Sailfish SDK >= 2.1) to make use of Qt's modern CMake3 modules.