### PR TITLE
WIP: load generic qml without libsailfishapp dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,46 @@
 project(cmakesample CXX)
 cmake_minimum_required(VERSION 3.5)
 
+# For the example we assume to always be compiling for SailfishOS.
+option(SAILFISHOS "set SailfishOS target" ON)
+option(SAILFISHAPP "Use libsailfishapp features" ON)
+
 find_package (Qt5 COMPONENTS Core Network Qml Gui Quick REQUIRED)
 
-include(FindPkgConfig)
-pkg_search_module(SAILFISH sailfishapp REQUIRED)
+if(SAILFISHOS)
+    include(FindPkgConfig)
+    if(SAILFISHAPP)
+        pkg_search_module(SAILFISH sailfishapp REQUIRED)
+        add_definitions(-DSAILFISHAPP)
+    else()
+        pkg_search_module(BOOSTER_MODULE qdeclarativecache5-boostable)
+        if(BOOSTER_MODULE)
+            message("Compiling with qdeclarative5-boostable support.")
+            add_definitions(-DHAS_BOOSTER)
+        else()
+            message(WARNING "qdeclarative5-boostable not available; startup times will be slower.")
+        endif()
+    endif()
+endif()
 
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 add_executable(cmakesample main.cpp)
-target_include_directories(cmakesample PRIVATE
-    $<BUILD_INTERFACE:
-    ${SAILFISH_INCLUDE_DIRS}
->)
-target_link_libraries(cmakesample
-    Qt5::Quick
-    ${SAILFISH_LDFLAGS}
-)
+if (SAILFISHOS)
+    target_include_directories(cmakesample PRIVATE
+        $<BUILD_INTERFACE:
+        ${SAILFISH_INCLUDE_DIRS}
+    >)
+    target_link_libraries(cmakesample
+        Qt5::Quick
+        ${SAILFISH_LDFLAGS}
+    )
+else()
+    target_link_libraries(cmakesample
+        Qt5::Quick
+    )
+endif()
 
 install(TARGETS cmakesample
     RUNTIME DESTINATION bin

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Example SailfishOS App using CMake
+This code example shows how to use CMake to build your own SailfishOS application.
+
+## Example 1: Using libsailfishapp
+The first example shows a simple and straight-forward approach to build a native SailfishOS application based on libsailfishapp.
+
+## Example 2: Generic application
+The second example just shows a customizable SailfishOS without depending on an additional library. While this approach requires some overhead by the developer, it probably integrates better with your existing, multi-platform code base. Other than that, it just shows the difference. You decide which suits your needs best.
+
+### Note for example 2
+Currently the declarative booster package is not found by CMake. To workaround this issue, please open the file `cmakesample.desktop` and comment the line `X-Nemo-Application-Type=silica-qt5`.
+
+## Building the examples
+The build process is straight-forward. Make sure to meet the following pre-conditions:
+
+1. MerSDK virtual machine is installed and running on your machine.
+2. Connect to your MerSDK instance: `ssh -p 2222 -i ~/SailfishOS/vmshare/ssh/private\_keys/engine/mersdk mersdk@localhost`
+3. Go to your project folder: e.g. `cd share/projects/cmakesample`
+
+Once you are all set you can build the example:
+
+```bash
+# replace version & target with your own strings
+export SFOS_TARGET=SailfishOS-2.2.0.29-armv7hl
+
+# build example 1
+mb2 -t $SFOS_TARGET build
+
+# build example 2
+mb2 -t $SFOS_TARGET build --without libsailfishapp
+```
+
+Feel free to play around with the example!

--- a/cmakesample.desktop
+++ b/cmakesample.desktop
@@ -1,5 +1,8 @@
 [Desktop Entry]
 Type=Application
+# Note:
+# Example 2 currently requires the declarative booster to be disabled.
+# Comment the following line to make it work.
 X-Nemo-Application-Type=silica-qt5
 Icon=cmakesample
 Exec=cmakesample

--- a/qml/cmakesample_generic.qml
+++ b/qml/cmakesample_generic.qml
@@ -1,0 +1,8 @@
+import QtQuick 2.0
+
+Rectangle {
+    width: 100
+    height: 100
+    color: "#baf"
+    Text { anchors.centerIn: parent; text: "CMake example with generic QML item." }
+}

--- a/rpm/cmakesample.spec
+++ b/rpm/cmakesample.spec
@@ -35,12 +35,26 @@ custom build system
 # >> setup
 # << setup
 
+%bcond_without sailfishos
+%bcond_without libsailfishapp
 %build
 # >> build pre
 rm -rf rpmbuilddir
 mkdir rpmbuilddir
-cd rpmbuilddir &&  cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr ..
-cd ..
+cd rpmbuilddir && cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/usr \
+%if %{with sailfishos}
+  -DSAILFISHOS=ON \
+%else
+  -DSAILFISHOS=OFF \
+%endif
+%if %{with libsailfishapp}
+  -DSAILFISHAPP=ON \
+%else
+  -DSAILFISHAPP=OFF \
+%endif
+  ..
+
+cd .. \
 make -C rpmbuilddir -j VERBOSE=1 %{?_smp_mflags}
 # << build pre
 


### PR DESCRIPTION
Provides an alternative example without requiring libsailfishapp as a dependency.

- [x] ~~Important: Merge #1 beforehand!~~
- [ ] make it "uncrash" (completion) :sun_behind_rain_cloud:
